### PR TITLE
Add leptonica's pixConvertRGBToGray to the api, and expose via Pix

### DIFF
--- a/Tesseract.Net20/Interop/LeptonicaApi.cs
+++ b/Tesseract.Net20/Interop/LeptonicaApi.cs
@@ -86,6 +86,12 @@ namespace Tesseract.Interop
         [DllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixDestroyColormap")]
         public static extern int pixDestroyColormap(IntPtr pix);
 
+        // pixconv.h functions
+
+        [DllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixConvertRGBToGray")]
+        public static extern IntPtr pixConvertRGBToGray(IntPtr pix, float rwt, float gwt, float bwt);
+
+
         // image analysis and manipulation functions
 
         // skew

--- a/Tesseract.Net20/Pix.cs
+++ b/Tesseract.Net20/Pix.cs
@@ -225,6 +225,20 @@ namespace Tesseract
             return new Pix(ppixd);
         }
 
+        /// <summary>
+        /// Conversion from RBG to 8bpp grayscale.
+        /// </summary>
+        /// <param name="rwt">Red weight</param>
+        /// <param name="gwt">Green weight</param>
+        /// <param name="bwt">Blue weight</param>
+        /// <returns></returns>
+        public Pix ConvertRGBToGray(float rwt, float gwt, float bwt)
+        {
+            var resultPixHandle = Interop.LeptonicaApi.pixConvertRGBToGray(handle, rwt, gwt, bwt);
+            if (resultPixHandle == IntPtr.Zero) throw new TesseractException("Failed to convert to grayscale.");
+            return new Pix(resultPixHandle);
+        }
+
         protected override void Dispose(bool disposing)
         {
             Interop.LeptonicaApi.pixDestroy(ref handle);

--- a/Tesseract.Tests/Leptonica/PixTests/ImageManipulationTests.cs
+++ b/Tesseract.Tests/Leptonica/PixTests/ImageManipulationTests.cs
@@ -46,5 +46,16 @@ namespace Tesseract.Tests.Leptonica.PixTests
                 }
             }
         }
+
+        [Test]
+        public void ConvertRGBToGrayTest()
+        {
+            using (var sourcePix = Pix.LoadFromFile(@".\Data\Conversion\photo_rgb_32bpp.tif"))
+            using (var grayscaleImage = sourcePix.ConvertRGBToGray(1.0F, 1.0F, 1.0F))
+            {
+                Assert.That(grayscaleImage.Depth, Is.EqualTo(8));
+                grayscaleImage.Save("grayscaleImage.bmp");
+            }
+        }
     }
 }


### PR DESCRIPTION
I've added support for the ConvertRGBToGray leptonica API call to the Pix class, following the Descew and OtsuBinarization examples, including an additional minimalistic unit test.
