### PR TITLE
add possibility to create a Pix from an in memory Tiff file

### DIFF
--- a/src/Tesseract/Interop/LeptonicaApi.cs
+++ b/src/Tesseract/Interop/LeptonicaApi.cs
@@ -95,6 +95,9 @@ namespace Tesseract.Interop
         [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixRead")]
         IntPtr pixRead(string filename);
 
+        [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixReadMemTiff")]
+        unsafe IntPtr pixReadMemTiff(byte* data, int length, int page);
+
         [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixWrite")]
         int pixWrite(string filename, HandleRef handle, ImageFormat format);
 

--- a/src/Tesseract/Pix.cs
+++ b/src/Tesseract/Pix.cs
@@ -77,7 +77,21 @@ namespace Tesseract
             }
             return Create(pixHandle);
         }
-        
+
+        public static Pix LoadTiffFromMemory(byte[] bytes)
+        {
+            IntPtr handle;
+            fixed (byte* ptr = bytes)
+            {
+                handle = Interop.LeptonicaApi.Native.pixReadMemTiff(ptr, bytes.Length, 0);
+            }
+            if (handle == IntPtr.Zero)
+            {
+                throw new IOException("Failed to load image from memory.");
+            }
+            return Create(handle);
+        }
+
         /// <summary>
         /// Creates a new pix instance using an existing handle to a pix structure.
         /// </summary>


### PR DESCRIPTION
This PR exposes the leptonica pixReadMemTiff function to the managed code.

This avoids creating a Bitmap (which internally uses GDI+, which uses a global lock, which causes contention on highly concurrent scenarios).

PS: i'm not very experienced with interop, so maybe there is a better way to send the data over to the unmanaged world.
