### PR TITLE
Support for Tesseract's PrintVariablesToFile added.

### DIFF
--- a/src/Tesseract/Interop/BaseApi.cs
+++ b/src/Tesseract/Interop/BaseApi.cs
@@ -211,6 +211,9 @@ namespace Tesseract.Interop
         float ChoiceIteratorGetConfidence(HandleRef handle);
 
         #endregion
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessBaseAPIPrintVariablesToFile")]
+        int BaseApiPrintVariablesToFile(HandleRef handle, string filename); 
 	}
 
 	internal static class TessApi

--- a/src/Tesseract/TesseractEngine.cs
+++ b/src/Tesseract/TesseractEngine.cs
@@ -529,6 +529,16 @@ namespace Tesseract
             return value != null;
         }
 
+        /// <summary>
+        /// Attempts to print the variables to the file.
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <returns></returns>
+        public bool TryPrintVariablesToFile(string filename)
+        {
+            return Interop.TessApi.Native.BaseApiPrintVariablesToFile(handle, filename) != 0;
+        }
+
         #endregion Config
 
         #region Event Handlers


### PR DESCRIPTION
This is the feature request in [issue 256](https://github.com/charlesw/tesseract/issues/256) as pull request.

It wraps function ` TessBaseAPIPrintVariablesToFile` in [`tesseract-ocr/api/capi.cpp`](https://github.com/tesseract-ocr/tesseract/blob/master/api/capi.cpp) to the new function `TesseractEngine.TryPrintVariablesToFile`. The name with prefix 'Try'  and the implementation is similar to `TesseractEngine.TryGetIntVariable` or `TesseractEngine.TryGetStringVariable`.
