### PR TITLE
Additions for ResultIterator

### DIFF
--- a/src/Tesseract/Interop/BaseApi.cs
+++ b/src/Tesseract/Interop/BaseApi.cs
@@ -169,6 +169,30 @@ namespace Tesseract.Interop
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorGetUTF8Text")]
         IntPtr ResultIteratorGetUTF8TextInternal(HandleRef handle, PageIteratorLevel level);
 
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordRecognitionLanguage")]
+        IntPtr ResultIteratorGetWordRecognitionLanguageInternal(HandleRef handle);
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordFontAttributes")]
+        IntPtr ResultIteratorGetWordFontAttributesInternal(HandleRef handle,
+                out int isBold, out int isItalic, out int isUnderlined,
+                out int isMonospace, out int isSerif, out int isSmallCaps,
+                out int pointSize, out int fontId);
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordIsFromDictionary")]
+        int ResultIteratorWordIsFromDictionary(HandleRef handle);
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordIsNumeric")]
+        int ResultIteratorWordIsNumeric(HandleRef handle);
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorSymbolIsSuperscript")]
+        int ResultIteratorSymbolIsSuperscript(HandleRef handle);
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorSymbolIsSubscript")]
+        int ResultIteratorSymbolIsSubscript(HandleRef handle);
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorSymbolIsDropcap")]
+        int ResultIteratorSymbolIsDropcap(HandleRef handle);
+
         #region Choice Iterator
 
         /// <summary>
@@ -213,7 +237,7 @@ namespace Tesseract.Interop
         #endregion
 
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessBaseAPIPrintVariablesToFile")]
-        int BaseApiPrintVariablesToFile(HandleRef handle, string filename); 
+        int BaseApiPrintVariablesToFile(HandleRef handle, string filename);
 	}
 
 	internal static class TessApi
@@ -268,7 +292,7 @@ namespace Tesseract.Interop
                 return null;
             }
         }
-		 
+
 		//Just Copied:
 		public static string BaseAPIGetHOCRText2(HandleRef handle,int pageNum) {
 			IntPtr txtHandle = Native.BaseAPIGetHOCRTextInternal(handle, pageNum);
@@ -383,8 +407,55 @@ namespace Tesseract.Interop
             }
         }
 
+        public static string ResultIteratorGetWordRecognitionLanguage(HandleRef handle)
+        {
+            IntPtr txtHandle = Native.ResultIteratorGetWordRecognitionLanguageInternal(handle);
+            if (txtHandle != IntPtr.Zero) {
+                var result = MarshalHelper.PtrToString(txtHandle, Encoding.UTF8);
+                // txtHandle must not be deleted, see method WordRecognistionLanguage
+                // in tesseract/ccmain/ltrresultiterator.h.
+                return result;
+            } else {
+                return null;
+            }
+        }
+
+        public static string ResultIteratorGetWordFontAttributes(HandleRef handle,
+                out bool isBold, out bool isItalic, out bool isUnderlined,
+                out bool isMonospace, out bool isSerif, out bool isSmallCaps,
+                out int pointSize, out int fontId)
+        {
+            int bold, italic, underlined, monospace, serif, smallCaps;
+            IntPtr txtHandle = Native.ResultIteratorGetWordFontAttributesInternal(handle,
+                    out bold, out italic, out underlined,
+                    out monospace, out serif, out smallCaps,
+                    out pointSize, out fontId);
+            if (txtHandle != IntPtr.Zero) {
+                var result = MarshalHelper.PtrToString(txtHandle, Encoding.UTF8);
+                // txtHandle must not be deleted, see method WordFontAttributes
+                // in tesseract/ccmain/ltrresultiterator.h.
+                isBold = Convert.ToBoolean(bold);
+                isItalic = Convert.ToBoolean(italic);
+                isUnderlined = Convert.ToBoolean(underlined);
+                isMonospace = Convert.ToBoolean(monospace);
+                isSerif = Convert.ToBoolean(serif);
+                isSmallCaps = Convert.ToBoolean(smallCaps);
+                return result;
+            } else {
+                isBold = false;
+                isItalic = false;
+                isUnderlined = false;
+                isMonospace = false;
+                isSerif = false;
+                isSmallCaps = false;
+                pointSize = 0;
+                fontId = -1;
+                return null;
+            }
+        }
+
         /// <summary>
-        /// Returns the null terminated UTF-8 encoded text string for the current choice           
+        /// Returns the null terminated UTF-8 encoded text string for the current choice
         /// </summary>
         /// <remarks>
         /// NOTE: Unlike LTRResultIterator::GetUTF8Text, the return points to an

--- a/src/Tesseract/ResultIterator.cs
+++ b/src/Tesseract/ResultIterator.cs
@@ -27,7 +27,123 @@ namespace Tesseract
 
             return Interop.TessApi.ResultIteratorGetUTF8Text(handle, level);
         }
-        
+
+        /// <summary>
+        /// Returns the name of the language used to recognize this word.
+        /// </summary>
+        public string GetWordRecognitionLanguage()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return String.Empty;
+            }
+
+            return Interop.TessApi.ResultIteratorGetWordRecognitionLanguage(handle);
+        }
+
+        /// <summary>
+        /// Returns the font attributes of the current word. If iterating at a higher
+        /// level object than words, e.g. text lines, then this will return the
+        /// attributes of the first word in that textline.
+        /// </summary>
+        /// <param name="isBold"><c>true</c> if the font is bold.</param>
+        /// <param name="isItalic"><c>true</c> if the font is italic.</param>
+        /// <param name="isUnderlined"><c>true</c> if the font is underlined.</param>
+        /// <param name="isMonospace"><c>true</c> if the font is a fixed pitch font.</param>
+        /// <param name="isSerif"><c>true</c> if the font has serifs.</param>
+        /// <param name="isSmallCaps"><c>true</c> if the characters are small capitals.</param>
+        /// <param name="pointSize">The point size is returned in printer's points (1/72 inch).</param>
+        /// <param name="fontId">The univeral font ID.</param>
+        /// <returns>A string representing a font name.</returns>
+        public string GetWordFontAttributes(
+                out bool isBold, out bool isItalic, out bool isUnderlined,
+                out bool isMonospace, out bool isSerif, out bool isSmallCaps,
+                out int pointSize, out int fontId)
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                isBold = false;
+                isItalic = false;
+                isUnderlined = false;
+                isMonospace = false;
+                isSerif = false;
+                isSmallCaps = false;
+                pointSize = 0;
+                fontId = -1;
+                return String.Empty;
+            }
+            return Interop.TessApi.ResultIteratorGetWordFontAttributes(handle,
+                    out isBold, out isItalic, out isUnderlined,
+                    out isMonospace, out isSerif, out isSmallCaps,
+                    out pointSize, out fontId);
+        }
+
+        /// <summary>
+        ///  Returns true if the current word was found in a dictionary.
+        /// </summary>
+        public bool WordIsFromDictionary()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+            return Interop.TessApi.Native.ResultIteratorWordIsFromDictionary(handle) != 0;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the current word is numeric.
+        /// </summary>
+        public bool WordIsNumeric()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+            return Interop.TessApi.Native.ResultIteratorWordIsNumeric(handle) != 0;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the current symbol is a superscript.
+        /// If iterating at a higher level object than symbols, e.g. words, then
+        /// this will return the attributes of the first symbol in that word.
+        /// </summary>
+        public bool SymbolIsSuperscript()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+            return Interop.TessApi.Native.ResultIteratorSymbolIsSuperscript(handle) != 0;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the current symbol is a subscript.
+        /// If iterating at a higher level object than symbols, e.g. words, then
+        /// this will return the attributes of the first symbol in that word.
+        /// </summary>
+        public bool SymbolIsSubscript()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+            return Interop.TessApi.Native.ResultIteratorSymbolIsSubscript(handle) != 0;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the current symbol is a dropcap.
+        /// If iterating at a higher level object than symbols, e.g. words, then
+        /// this will return the attributes of the first symbol in that word.
+        /// </summary>
+        public bool SymbolIsDropcap()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+            return Interop.TessApi.Native.ResultIteratorSymbolIsDropcap(handle) != 0;
+        }
+
         /// <summary>
         /// Gets an instance of a choice iterator using the current symbol of interest. The ChoiceIterator allows a one-shot iteration over the
         /// choices for this symbol and after that is is useless.


### PR DESCRIPTION
Support for additional methods for `ResultIterator`:

```
tesseract::LTRResultIterator -> Tesseract.ResultIterator
--------------------------------------------------------
WordRecognitionLanguage      -> GetWordRecognitionLanguage
WordFontAttributes           -> GetWordFontAttributes
WordIfFromDictionary         -> WordIsFromDictionary
WordIsNumeric                -> WordIsNumeric
SymbolIsSuperscript          -> SymbolIsSuperscript
SymbolIsSubscript            -> SymbolIsSubscript
SymbolIsDropcap              -> SymbolIsDropcap
```
