### PR TITLE
Use multiple renderers in same process

### DIFF
--- a/src/Tesseract.Tests/ResultRendererTests.cs
+++ b/src/Tesseract.Tests/ResultRendererTests.cs
@@ -42,7 +42,7 @@ namespace Tesseract.Tests
             }
 
             var expectedOutputFilename = Path.ChangeExtension(resultPath, "txt");
-            Assert.That(File.Exists(expectedOutputFilename), $"Expected a Text file \"{expectedOutputFilename}\" to have been created; but non was found.");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a Text file \"{expectedOutputFilename}\" to have been created; but none was found.");
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace Tesseract.Tests
             }
 
             var expectedOutputFilename = Path.ChangeExtension(resultPath, "pdf");
-            Assert.That(File.Exists(expectedOutputFilename), $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but non was found.");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but none was found.");
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace Tesseract.Tests
             }
 
             var expectedOutputFilename = Path.ChangeExtension(resultPath, "pdf");
-            Assert.That(File.Exists(expectedOutputFilename), $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but non was found.");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but none was found.");
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace Tesseract.Tests
             }
 
             var expectedOutputFilename = Path.ChangeExtension(resultPath, "hocr");
-            Assert.That(File.Exists(expectedOutputFilename), $"Expected a HOCR file \"{expectedOutputFilename}\" to have been created; but non was found.");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a HOCR file \"{expectedOutputFilename}\" to have been created; but none was found.");
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace Tesseract.Tests
             }
 
             var expectedOutputFilename = Path.ChangeExtension(resultPath, "unlv");
-            Assert.That(File.Exists(expectedOutputFilename), $"Expected a Unlv file \"{expectedOutputFilename}\" to have been created; but non was found.");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a Unlv file \"{expectedOutputFilename}\" to have been created; but none was found.");
         }
 
         [Test]
@@ -107,7 +107,26 @@ namespace Tesseract.Tests
             }
 
             var expectedOutputFilename = Path.ChangeExtension(resultPath, "box");
-            Assert.That(File.Exists(expectedOutputFilename), $"Expected a Box file \"{expectedOutputFilename}\" to have been created; but non was found.");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a Box file \"{expectedOutputFilename}\" to have been created; but none was found.");
+        }
+
+        [Test]
+        public void CanRenderResultsIntoMultipleOutputFormats()
+        {
+            var resultPath = TestResultRunFile(@"ResultRenderers\PDF\phototest");
+            List<RenderedFormat> formats = new List<RenderedFormat> { RenderedFormat.HOCR, RenderedFormat.PDF, RenderedFormat.TEXT };
+            using (var renderer = ResultRenderer.CreateRenderers(resultPath, DataPath, formats))
+            {
+                var examplePixPath = this.TestFilePath("Ocr/phototest.tif");
+                ProcessFile(renderer, examplePixPath);
+            }
+
+            var expectedOutputFilename = Path.ChangeExtension(resultPath, "pdf");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but none was found.");
+            expectedOutputFilename = Path.ChangeExtension(resultPath, "hocr");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a HOCR file \"{expectedOutputFilename}\" to have been created; but none was found.");
+            expectedOutputFilename = Path.ChangeExtension(resultPath, "txt");
+            Assert.That(File.Exists(expectedOutputFilename), $"Expected a TEXT file \"{expectedOutputFilename}\" to have been created; but none was found.");
         }
 
         private void ProcessMultipageTiff(IResultRenderer renderer, string filename)

--- a/src/Tesseract/ResultRenderer.cs
+++ b/src/Tesseract/ResultRenderer.cs
@@ -1,9 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Tesseract.Internal;
 
 namespace Tesseract
 {
+    /// <summary>
+    /// Rendered formats supported by Tesseract.
+    /// </summary>
+    public enum RenderedFormat
+    {
+        TEXT, HOCR, PDF, UNLV, BOX
+    }
+
     /// <summary>
     /// Represents a native result renderer (e.g. text, pdf, etc).
     /// </summary>
@@ -15,6 +24,78 @@ namespace Tesseract
     public abstract class ResultRenderer : DisposableBase, IResultRenderer
     {
         #region Factory Methods
+
+        /// <summary>
+        /// Creates renderers for specified output formats.
+        /// </summary>
+        /// <param name="outputbase"></param>
+        /// <param name="dataPath"></param>
+        /// <param name="outputFormats"></param>
+        /// <returns></returns>
+        public static IResultRenderer CreateRenderers(string outputbase, string dataPath, List<RenderedFormat> outputFormats)
+        {
+            IResultRenderer renderer = null;
+
+            foreach (RenderedFormat format in outputFormats)
+            {
+                switch (format)
+                {
+                    case RenderedFormat.TEXT:
+                        if (renderer == null)
+                        {
+                            renderer = CreateTextRenderer(outputbase);
+                        }
+                        else
+                        {
+                            Interop.TessApi.Native.ResultRendererInsert(((ResultRenderer)renderer).Handle, new TextResultRenderer(outputbase).Handle);
+                        }
+                        break;
+                    case RenderedFormat.HOCR:
+                        if (renderer == null)
+                        {
+                            renderer = CreateHOcrRenderer(outputbase);
+                        }
+                        else
+                        {
+                            Interop.TessApi.Native.ResultRendererInsert(((ResultRenderer)renderer).Handle, new HOcrResultRenderer(outputbase).Handle);
+                        }
+                        break;
+                    case RenderedFormat.PDF:
+                        //dataPath = Interop.TessApi.Native.BaseAPIGetDatapath(handle);
+                        if (renderer == null)
+                        {
+                            renderer = CreatePdfRenderer(outputbase, dataPath);
+                        }
+                        else
+                        {
+                            Interop.TessApi.Native.ResultRendererInsert(((ResultRenderer)renderer).Handle, new PdfResultRenderer(outputbase, dataPath).Handle);
+                        }
+                        break;
+                    case RenderedFormat.BOX:
+                        if (renderer == null)
+                        {
+                            renderer = CreateBoxRenderer(outputbase);
+                        }
+                        else
+                        {
+                            Interop.TessApi.Native.ResultRendererInsert(((ResultRenderer)renderer).Handle, new BoxResultRenderer(outputbase).Handle);
+                        }
+                        break;
+                    case RenderedFormat.UNLV:
+                        if (renderer == null)
+                        {
+                            renderer = CreateUnlvRenderer(outputbase);
+                        }
+                        else
+                        {
+                            Interop.TessApi.Native.ResultRendererInsert(((ResultRenderer)renderer).Handle, new UnlvResultRenderer(outputbase).Handle);
+                        }
+                        break;
+                }
+            }
+
+            return renderer;
+        }
 
         /// <summary>
         /// Creates a <see cref="IResultRenderer">result renderer</see> that render that generates a searchable


### PR DESCRIPTION
If we could make `dataPath = Interop.TessApi.Native.BaseAPIGetDatapath(handle);` work, the method's `dataPath` parameter could be eliminated.