### PR TITLE
Clear unmanaged resources on implicit dispose.

### DIFF
--- a/src/Tesseract/EngineMode.cs
+++ b/src/Tesseract/EngineMode.cs
@@ -7,8 +7,10 @@ namespace Tesseract
 	public enum EngineMode : int
 	{
 		TesseractOnly = 0, 
+        LstmOnly,
+        TesseractAndLstm,
+        Default,
 		CubeOnly, 
-		TesseractAndCube, 
-		Default
+		TesseractAndCube
 	}
 }

--- a/src/Tesseract/Interop/BaseApi.cs
+++ b/src/Tesseract/Interop/BaseApi.cs
@@ -41,9 +41,6 @@ namespace Tesseract.Interop
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessBaseAPIDelete")]
         void BaseApiDelete(HandleRef ptr);
 
-        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessBaseAPIDetectOS")]
-        int BaseAPIDetectOS(HandleRef handle, ref OSResult result);
-
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessBaseAPIGetBoolVariable")]
         int BaseApiGetBoolVariable(HandleRef handle, string name, out int value);
 

--- a/src/Tesseract/Interop/Constants.cs
+++ b/src/Tesseract/Interop/Constants.cs
@@ -7,8 +7,8 @@ namespace Tesseract.Interop
     /// </summary>
     internal static class Constants
     {
-        public const string LeptonicaDllName = "liblept172";
-        public const string TesseractDllName = "libtesseract304";
+        public const string LeptonicaDllName = "liblept1741";
+        public const string TesseractDllName = "libtesseract400";
         
         // tesseract uses an int to represent true false values.
         public const int TRUE = 1;

--- a/src/Tesseract/Interop/LeptonicaApi.cs
+++ b/src/Tesseract/Interop/LeptonicaApi.cs
@@ -435,12 +435,6 @@ namespace Tesseract.Interop
         [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixcmapGetNearestGrayIndex")]
         int pixcmapGetNearestGrayIndex(HandleRef cmap, int val, out int index);
 
-        [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixcmapGetComponentRange")]
-        int pixcmapGetComponentRange(HandleRef cmap, int component, out int minVal, out int maxVal);
-
-        [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixcmapGetExtremeValue")]
-        int pixcmapGetExtremeValue(HandleRef cmap, int type, out int rVal, out int gVal, out int bVal);
-
         // color map conversion
 
         [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixcmapGrayToColor")]

--- a/src/Tesseract/Page.cs
+++ b/src/Tesseract/Page.cs
@@ -225,7 +225,7 @@ namespace Tesseract
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing) {
+            if (!IsDisposed) {
                 Interop.TessApi.Native.BaseAPIClear(Engine.Handle);
             }
         }

--- a/src/Tesseract/Page.cs
+++ b/src/Tesseract/Page.cs
@@ -190,11 +190,11 @@ namespace Tesseract
         {
             Interop.OSResult result = new Interop.OSResult();
             result.Init();
-            if (Interop.TessApi.Native.BaseAPIDetectOS(Engine.Handle, ref result) != 0) {
-                result.GetBestOrientation(out orientation, out confidence);
-            } else {
+            //if (Interop.TessApi.Native.BaseAPIDetectOS(Engine.Handle, ref result) != 0) {
+            //    result.GetBestOrientation(out orientation, out confidence);
+            //} else {
                 throw new TesseractException("Failed to detect image orientation.");
-            }
+            //}
         }
         
         internal void Recognize()

--- a/src/Tesseract/PageSegMode.cs
+++ b/src/Tesseract/PageSegMode.cs
@@ -65,6 +65,21 @@ namespace Tesseract
         SingleChar, 
         
         /// <summary>
+        /// Find as much text as possible in no particular order.
+        /// </summary>
+	SparseText,
+        
+        /// <summary>
+        /// Sparse text with orientation and script det.
+        /// </summary>
+	SparseTextOsd,
+        
+        /// <summary>
+        /// Treat the image as a single text line, bypassing hacks that are Tesseract-specific.
+        /// </summary>
+	RawLine,
+        
+        /// <summary>
         /// Number of enum entries.
         /// </summary>
         Count


### PR DESCRIPTION
Unmanaged resources should be cleared if the GC calls finallizer instead of the user.  This only impacts users that forget to dispose properly.