### PR TITLE
Feature/9 font attributes

### DIFF
--- a/src/Tesseract/FontAttributes.cs
+++ b/src/Tesseract/FontAttributes.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Tesseract
+{
+    // This class is the return type of
+    // ResultIterator.GetWordFontAttributes().  We can't
+    // use FontInfo directly because there are properties
+    // here that are not accounted for in FontInfo
+    // (smallcaps, underline, etc.)  Because of the caching
+    // scheme we're using for FontInfo objects, we can't simply
+    // augment that class since these extra properties are not
+    // accounted for by the FontInfo's unique ID.
+    public class FontAttributes
+    {
+        public FontInfo FontInfo { get; private set; }
+
+        public bool IsUnderlined { get; private set; }
+        public bool IsSmallCaps { get; private set; }
+        public int PointSize { get; private set; }
+
+        public FontAttributes(
+            FontInfo fontInfo, bool isUnderlined, bool isSmallCaps, int pointSize)
+        {
+            FontInfo = fontInfo;
+            IsUnderlined = isUnderlined;
+            IsSmallCaps = isSmallCaps;
+            PointSize = pointSize;
+        }
+    }
+}

--- a/src/Tesseract/FontInfo.cs
+++ b/src/Tesseract/FontInfo.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tesseract
+{
+    // See github:tesseract-ocr/tesseract#a75ab45
+    // ccstruct/fontinfo.h:111 to see where these
+    // values came from
+    [Flags]
+    public enum FontProperties
+    {
+        None       = 0,
+        Italic     = 1 << 0,
+        Bold       = 1 << 1,
+        FixedPitch = 1 << 2,
+        Serif      = 1 << 3,
+        Fraktur    = 1 << 4
+    }
+
+    // The .NET equivalent of the ccstruct/fontinfo.h
+    // FontInfo struct. It's missing spacing info
+    // since we don't have any way of getting it (and
+    // it's probably not all that useful anyway)
+    public class FontInfo
+    {
+        private FontInfo(string name, int id, FontProperties properties)
+        {
+            Name = name;
+            Id = id;
+            Properties = properties;
+        }
+
+        private T GetFlag<T>(bool isSet, T flagValue)
+        {
+            return isSet ? flagValue : default(T);
+        }
+
+        // .NET < 4 doesn't have Enum.HasFlag, so for compatibility
+        // we'll use our own.
+        private bool HasFlag<T>(T value, T flag)
+        {
+            var val = Convert.ToInt32(value);
+            var f   = Convert.ToInt32(flag);
+
+            return (val & f) == f;
+        }
+
+        private FontInfo(
+            string name, int id,
+            bool isItalic, bool isBold, bool isFixedPitch,
+            bool isSerif, bool isFraktur = false
+        )
+        {
+            Name = name;
+            Id = id;
+            Properties =
+                GetFlag(isItalic, FontProperties.Italic)
+                    | GetFlag(isBold, FontProperties.Bold)
+                    | GetFlag(isFixedPitch, FontProperties.FixedPitch)
+                    | GetFlag(isSerif, FontProperties.Serif)
+                    | GetFlag(isFraktur, FontProperties.Fraktur);
+        }
+
+        public string Name { get; private set; }
+        public int    Id   { get; private set; }
+
+        public FontProperties Properties { get; private set; }
+
+        public bool IsItalic     { get { return HasFlag(Properties, FontProperties.Italic);     } }
+        public bool IsBold       { get { return HasFlag(Properties, FontProperties.Bold);       } }
+        public bool IsFixedPitch { get { return HasFlag(Properties, FontProperties.FixedPitch); } }
+        public bool IsSerif      { get { return HasFlag(Properties, FontProperties.Serif);      } }
+        public bool IsFraktur    { get { return HasFlag(Properties, FontProperties.Fraktur);    } }
+
+        private static Dictionary<int, FontInfo> _cache = new Dictionary<int, FontInfo>();
+
+        public static FontInfo GetById(int id) {
+            if (_cache.ContainsKey(id)) {
+                return _cache[id];
+            }
+            return null;
+        }
+
+        public static FontInfo GetOrCreate(
+            string name, int id,
+            bool isItalic, bool isBold, bool isFixedPitch,
+            bool isSerif, bool isFraktur = false
+        )
+        {
+            if (_cache.ContainsKey(id)) {
+                return _cache[id];
+            }
+
+            var newFont = new FontInfo(name, id, isItalic, isBold, isFixedPitch, isSerif, isFraktur);
+            _cache.Add(id, newFont);
+
+            return newFont;
+        }
+    }
+}

--- a/src/Tesseract/FontInfo.cs
+++ b/src/Tesseract/FontInfo.cs
@@ -3,48 +3,12 @@ using System.Collections.Generic;
 
 namespace Tesseract
 {
-    // See github:tesseract-ocr/tesseract#a75ab45
-    // ccstruct/fontinfo.h:111 to see where these
-    // values came from
-    [Flags]
-    public enum FontProperties
-    {
-        None       = 0,
-        Italic     = 1 << 0,
-        Bold       = 1 << 1,
-        FixedPitch = 1 << 2,
-        Serif      = 1 << 3,
-        Fraktur    = 1 << 4
-    }
-
     // The .NET equivalent of the ccstruct/fontinfo.h
     // FontInfo struct. It's missing spacing info
     // since we don't have any way of getting it (and
     // it's probably not all that useful anyway)
     public class FontInfo
     {
-        private FontInfo(string name, int id, FontProperties properties)
-        {
-            Name = name;
-            Id = id;
-            Properties = properties;
-        }
-
-        private T GetFlag<T>(bool isSet, T flagValue)
-        {
-            return isSet ? flagValue : default(T);
-        }
-
-        // .NET < 4 doesn't have Enum.HasFlag, so for compatibility
-        // we'll use our own.
-        private bool HasFlag<T>(T value, T flag)
-        {
-            var val = Convert.ToInt32(value);
-            var f   = Convert.ToInt32(flag);
-
-            return (val & f) == f;
-        }
-
         private FontInfo(
             string name, int id,
             bool isItalic, bool isBold, bool isFixedPitch,
@@ -53,24 +17,22 @@ namespace Tesseract
         {
             Name = name;
             Id = id;
-            Properties =
-                GetFlag(isItalic, FontProperties.Italic)
-                    | GetFlag(isBold, FontProperties.Bold)
-                    | GetFlag(isFixedPitch, FontProperties.FixedPitch)
-                    | GetFlag(isSerif, FontProperties.Serif)
-                    | GetFlag(isFraktur, FontProperties.Fraktur);
+
+            IsItalic     = isItalic;
+            IsBold       = isBold;
+            IsFixedPitch = isFixedPitch;
+            IsSerif      = isSerif;
+            IsFraktur    = isFraktur;
         }
 
         public string Name { get; private set; }
-        public int    Id   { get; private set; }
 
-        public FontProperties Properties { get; private set; }
-
-        public bool IsItalic     { get { return HasFlag(Properties, FontProperties.Italic);     } }
-        public bool IsBold       { get { return HasFlag(Properties, FontProperties.Bold);       } }
-        public bool IsFixedPitch { get { return HasFlag(Properties, FontProperties.FixedPitch); } }
-        public bool IsSerif      { get { return HasFlag(Properties, FontProperties.Serif);      } }
-        public bool IsFraktur    { get { return HasFlag(Properties, FontProperties.Fraktur);    } }
+        public int  Id           { get; private set; }
+        public bool IsItalic     { get; private set; }
+        public bool IsBold       { get; private set; }
+        public bool IsFixedPitch { get; private set; }
+        public bool IsSerif      { get; private set; }
+        public bool IsFraktur    { get; private set; }
 
         private static Dictionary<int, FontInfo> _cache = new Dictionary<int, FontInfo>();
 
@@ -81,20 +43,23 @@ namespace Tesseract
             return null;
         }
 
+        public static object _cacheLock = new object();
         public static FontInfo GetOrCreate(
             string name, int id,
             bool isItalic, bool isBold, bool isFixedPitch,
             bool isSerif, bool isFraktur = false
         )
         {
-            if (_cache.ContainsKey(id)) {
-                return _cache[id];
+            lock (_cacheLock) {
+                if (_cache.ContainsKey(id)) {
+                    return _cache[id];
+                }
+
+                var newFont = new FontInfo(name, id, isItalic, isBold, isFixedPitch, isSerif, isFraktur);
+                _cache.Add(id, newFont);
+
+                return newFont;
             }
-
-            var newFont = new FontInfo(name, id, isItalic, isBold, isFixedPitch, isSerif, isFraktur);
-            _cache.Add(id, newFont);
-
-            return newFont;
         }
     }
 }

--- a/src/Tesseract/FontInfo.cs
+++ b/src/Tesseract/FontInfo.cs
@@ -9,7 +9,7 @@ namespace Tesseract
     // it's probably not all that useful anyway)
     public class FontInfo
     {
-        private FontInfo(
+        internal FontInfo(
             string name, int id,
             bool isItalic, bool isBold, bool isFixedPitch,
             bool isSerif, bool isFraktur = false
@@ -33,33 +33,5 @@ namespace Tesseract
         public bool IsFixedPitch { get; private set; }
         public bool IsSerif      { get; private set; }
         public bool IsFraktur    { get; private set; }
-
-        private static Dictionary<int, FontInfo> _cache = new Dictionary<int, FontInfo>();
-
-        public static FontInfo GetById(int id) {
-            if (_cache.ContainsKey(id)) {
-                return _cache[id];
-            }
-            return null;
-        }
-
-        public static object _cacheLock = new object();
-        public static FontInfo GetOrCreate(
-            string name, int id,
-            bool isItalic, bool isBold, bool isFixedPitch,
-            bool isSerif, bool isFraktur = false
-        )
-        {
-            lock (_cacheLock) {
-                if (_cache.ContainsKey(id)) {
-                    return _cache[id];
-                }
-
-                var newFont = new FontInfo(name, id, isItalic, isBold, isFixedPitch, isSerif, isFraktur);
-                _cache.Add(id, newFont);
-
-                return newFont;
-            }
-        }
     }
 }

--- a/src/Tesseract/Interop/BaseApi.cs
+++ b/src/Tesseract/Interop/BaseApi.cs
@@ -182,7 +182,7 @@ namespace Tesseract.Interop
         float ResultIteratorGetConfidence(HandleRef handle, PageIteratorLevel level);
 
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordFontAttributes")]
-        IntPtr ResultIteratorWordFontAttributesInternal(HandleRef handle, out bool is_bold, out bool is_italic, out bool is_underlined, out bool is_monospace, out bool is_serif, out bool is_smallcaps, out int pointsize, out int font_id);
+        IntPtr ResultIteratorWordFontAttributes(HandleRef handle, out bool isBold, out bool isItalic, out bool isUnderlined, out bool isMonospace, out bool isSerif, out bool isSmallCaps, out int pointSize, out int fontId);
 
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordIsFromDictionary")]
         bool ResultIteratorWordIsFromDictionary(HandleRef handle);
@@ -459,40 +459,6 @@ namespace Tesseract.Interop
                 LeptonicaApi.Initialize();
                 native = InteropRuntimeImplementer.CreateInstance<ITessApiSignatures>();
             }
-        }
-
-        public static FontAttributes ResultIteratorWordFontAttributes(HandleRef handle)
-        {
-            bool is_bold, is_italic, is_underlined,
-                 is_monospace, is_serif, is_smallcaps;
-
-            int pointsize, font_id;
-
-            // per docs (ltrresultiterator.h:104 as of 4897796 in github:tesseract-ocr/tesseract)
-            // this return value points to an internal table and should not be deleted.
-            IntPtr txtHandle =
-                Native.ResultIteratorWordFontAttributesInternal(
-                    handle,
-                    out is_bold, out is_italic, out is_underlined,
-                    out is_monospace, out is_serif, out is_smallcaps,
-                    out pointsize, out font_id
-                );
-
-            // this can happen in certain error conditions.
-            if (txtHandle == IntPtr.Zero) {
-                return null;
-            }
-
-            var fontInfo =
-                FontInfo.GetById(font_id)
-                    ?? FontInfo.GetOrCreate(
-                           MarshalHelper.PtrToString(txtHandle, Encoding.UTF8),
-                           font_id,
-                           is_italic, is_bold,
-                           is_monospace, is_serif
-                       );
-
-            return new FontAttributes(fontInfo, is_underlined, is_smallcaps, pointsize);
         }
 
         public static string ResultIteratorWordRecognitionLanguage(HandleRef handle)

--- a/src/Tesseract/Interop/BaseApi.cs
+++ b/src/Tesseract/Interop/BaseApi.cs
@@ -181,6 +181,12 @@ namespace Tesseract.Interop
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorConfidence")]
         float ResultIteratorGetConfidence(HandleRef handle, PageIteratorLevel level);
 
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordFontAttributes")]
+        IntPtr ResultIteratorWordFontAttributesInternal(HandleRef handle, out bool is_bold, out bool is_italic, out bool is_underlined, out bool is_monospace, out bool is_serif, out bool is_smallcaps, out int pointsize, out int font_id);
+
+        [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorWordRecognitionLanguage")]
+        IntPtr ResultIteratorWordRecognitionLanguageInternal(HandleRef handle);
+
         [RuntimeDllImport(Constants.TesseractDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "TessResultIteratorGetPageIterator")]
         IntPtr ResultIteratorGetPageIterator(HandleRef handle);
 
@@ -438,6 +444,40 @@ namespace Tesseract.Interop
                 LeptonicaApi.Initialize();
                 native = InteropRuntimeImplementer.CreateInstance<ITessApiSignatures>();
             }
+        }
+
+        public static string ResultIteratorWordFontAttributes(
+            HandleRef handle,
+            out bool is_bold, out bool is_italic, out bool is_underlined,
+            out bool is_monospace, out bool is_serif, out bool is_smallcaps,
+            out int pointsize, out int font_id
+        )
+        {
+            // per docs (ltrresultiterator.h:104 as of 4897796 in github:tesseract-ocr/tesseract)
+            // this return value points to an internal table and should not be deleted.
+            IntPtr txtHandle =
+                Native.ResultIteratorWordFontAttributesInternal(
+                    handle,
+                    out is_bold, out is_italic, out is_underlined,
+                    out is_monospace, out is_serif, out is_smallcaps,
+                    out pointsize, out font_id
+                );
+
+            return txtHandle != IntPtr.Zero
+                ? MarshalHelper.PtrToString(txtHandle, Encoding.UTF8)
+                : null;
+        }
+
+        public static string ResultIteratorWordRecognitionLanguage(HandleRef handle)
+        {
+            // per docs (ltrresultiterator.h:118 as of 4897796 in github:tesseract-ocr/tesseract)
+            // this return value should *NOT* be deleted.
+            IntPtr txtHandle =
+                Native.ResultIteratorWordRecognitionLanguageInternal(handle);
+
+            return txtHandle != IntPtr.Zero
+                ? MarshalHelper.PtrToString(txtHandle, Encoding.UTF8)
+                : null;
         }
 
         public static string ResultIteratorGetUTF8Text(HandleRef handle, PageIteratorLevel level)

--- a/src/Tesseract/ResultIterator.cs
+++ b/src/Tesseract/ResultIterator.cs
@@ -28,6 +28,49 @@ namespace Tesseract
             return Interop.TessApi.ResultIteratorGetUTF8Text(handle, level);
         }
         
+        public FontAttributes GetWordFontAttributes() {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return null;
+            }
+
+            bool is_bold, is_italic, is_underlined,
+                    is_monospace, is_serif, is_smallcaps;
+
+            int pointsize, font_id;
+            string name =
+                Interop.TessApi.ResultIteratorWordFontAttributes(
+                    handle,
+                    out is_bold, out is_italic, out is_underlined,
+                    out is_monospace, out is_serif, out is_smallcaps,
+                    out pointsize, out font_id
+                );
+
+            // this can happen in certain error conditions.
+            if (name == null) {
+                return null;
+            }
+
+            var fontInfo =
+                FontInfo.GetOrCreate(
+                    name, font_id,
+                    is_italic, is_bold,
+                    is_monospace, is_serif
+                );
+
+            return new FontAttributes(fontInfo, is_underlined, is_smallcaps, pointsize);
+        }
+
+        public string GetWordRecognitionLanguage()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return null;
+            }
+
+            return Interop.TessApi.ResultIteratorWordRecognitionLanguage(handle);
+        }
+
         /// <summary>
         /// Gets an instance of a choice iterator using the current symbol of interest. The ChoiceIterator allows a one-shot iteration over the
         /// choices for this symbol and after that is is useless.

--- a/src/Tesseract/ResultIterator.cs
+++ b/src/Tesseract/ResultIterator.cs
@@ -34,31 +34,7 @@ namespace Tesseract
                 return null;
             }
 
-            bool is_bold, is_italic, is_underlined,
-                    is_monospace, is_serif, is_smallcaps;
-
-            int pointsize, font_id;
-            string name =
-                Interop.TessApi.ResultIteratorWordFontAttributes(
-                    handle,
-                    out is_bold, out is_italic, out is_underlined,
-                    out is_monospace, out is_serif, out is_smallcaps,
-                    out pointsize, out font_id
-                );
-
-            // this can happen in certain error conditions.
-            if (name == null) {
-                return null;
-            }
-
-            var fontInfo =
-                FontInfo.GetOrCreate(
-                    name, font_id,
-                    is_italic, is_bold,
-                    is_monospace, is_serif
-                );
-
-            return new FontAttributes(fontInfo, is_underlined, is_smallcaps, pointsize);
+            return Interop.TessApi.ResultIteratorWordFontAttributes(handle);
         }
 
         public string GetWordRecognitionLanguage()
@@ -69,6 +45,56 @@ namespace Tesseract
             }
 
             return Interop.TessApi.ResultIteratorWordRecognitionLanguage(handle);
+        }
+
+        public bool GetWordIsFromDictionary()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+
+            return Interop.TessApi.Native.ResultIteratorWordIsFromDictionary(handle);
+        }
+
+        public bool GetWordIsNumeric()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+
+            return Interop.TessApi.Native.ResultIteratorWordIsNumeric(handle);
+        }
+
+        public bool GetSymbolIsSuperscript()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+
+            return Interop.TessApi.Native.ResultIteratorSymbolIsSuperscript(handle);
+        }
+
+        public bool GetSymbolIsSubscript()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+
+            return Interop.TessApi.Native.ResultIteratorSymbolIsSubscript(handle);
+        }
+
+        public bool GetSymbolIsDropcap()
+        {
+            VerifyNotDisposed();
+            if (handle.Handle == IntPtr.Zero) {
+                return false;
+            }
+
+            return Interop.TessApi.Native.ResultIteratorSymbolIsDropcap(handle);
         }
 
         /// <summary>

--- a/src/Tesseract/ResultIterator.cs
+++ b/src/Tesseract/ResultIterator.cs
@@ -51,6 +51,11 @@ namespace Tesseract
                     out isMonospace, out isSerif, out isSmallCaps,
                     out pointSize, out fontId);
 
+            // This can happen in certain error conditions
+            if (nameHandle == IntPtr.Zero) {
+                return null;
+            }
+
             FontInfo fontInfo;
             if (!_fontInfoCache.TryGetValue(fontId, out fontInfo)) {
                 string fontName = MarshalHelper.PtrToString(nameHandle, Encoding.UTF8);

--- a/src/Tesseract/Tesseract.csproj
+++ b/src/Tesseract/Tesseract.csproj
@@ -102,6 +102,8 @@
     <Compile Include="PolyBlockType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rect.cs" />
+    <Compile Include="FontAttributes.cs" />
+    <Compile Include="FontInfo.cs" />
     <Compile Include="ResultIterator.cs" />
     <Compile Include="TesseractEnviornment.cs">
       <SubType>Code</SubType>


### PR DESCRIPTION
* Add a FontInfo class that mirrors Tesseract's own FontInfo struct.  This contains the font attributes that are cacheable by ID.
* Add a FontAttributes class to serve as the return value of GetWordFontAttributes()
* Add the necessary glue to actually get the word font attributes from the native side
* Wrap a few other "low-hanging fruit" API calls (WordRecognitionLanguage, WordIsFromDictionary, etc)