### PR TITLE
Expose Pix resolution fetch methods.

### DIFF
--- a/src/Tesseract/Pix.cs
+++ b/src/Tesseract/Pix.cs
@@ -160,6 +160,16 @@ namespace Tesseract
         {
             get { return width; }
         }
+	
+	public int XRes
+	{
+	    get { return Interop.LeptonicaApi.Native.pixGetXRes(this.handle); }
+	}
+	
+	public int YRes
+	{
+	    get { return Interop.LeptonicaApi.Native.pixGetYRes(this.handle); }
+	}
 
         internal HandleRef Handle
         {


### PR DESCRIPTION
Image manipulation decisions are frequently based on the resolution of the image.  Expose the resolution properties so those decisions can be made.