### PR TITLE
added quotes around nuget.exe to handle paths with spaces in them

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -60,7 +60,7 @@
     </CreateItem>
   </Target>
   <Target Name="RestorePackages">
-    <Exec Command='$(ToolsDir)\NuGet.exe restore "$(SourceDir)\Tesseract.sln"' />
+    <Exec Command='"$(ToolsDir)\NuGet.exe" restore "$(SourceDir)\Tesseract.sln"' />
   </Target>
   <Target Name="Clean" DependsOnTargets="ExpandFlavors;RestorePackages">
     <MSBuild Projects="@(ProjectToBuild)" Targets="Clean" />


### PR DESCRIPTION
Just a small fix that I needed to run the clean.bat on my computer.