### PR TITLE
Add LeptonicaAPI pixReadMem function.

### DIFF
--- a/src/Tesseract/Interop/LeptonicaApi.cs
+++ b/src/Tesseract/Interop/LeptonicaApi.cs
@@ -109,6 +109,9 @@ namespace Tesseract.Interop
         [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixRead")]
         IntPtr pixRead(string filename);
 
+        [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixReadMem")]
+        unsafe IntPtr pixReadMem(byte* data, int length);
+
         [RuntimeDllImport(Constants.LeptonicaDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pixReadMemTiff")]
         unsafe IntPtr pixReadMemTiff(byte* data, int length, int page);
 

--- a/src/Tesseract/Pix.cs
+++ b/src/Tesseract/Pix.cs
@@ -106,6 +106,20 @@ namespace Tesseract
             return Create(pixHandle);
         }
 
+        public static Pix LoadFromMemory(byte[] bytes)
+        {
+	        IntPtr handle;
+	        fixed (byte* ptr = bytes)
+	        {
+		        handle = Interop.LeptonicaApi.Native.pixReadMem(ptr, bytes.Length);
+	        }
+	        if (handle == IntPtr.Zero)
+	        {
+		        throw new IOException("Failed to load image from memory.");
+	        }
+	        return Create(handle);
+		}
+
         public static Pix LoadTiffFromMemory(byte[] bytes)
         {
             IntPtr handle;


### PR DESCRIPTION
Exposes the pixReadMem function in order to allow the opening of images (aside from just tiff) from byte arrays.