### PR TITLE
Fix dynamic linking on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [ 'ci-test' ]
+  pull_request:
+    branches: [ 'main', 'develop' ]
+    paths:
+    - '**.cs'
+    - '**.csproj'
+
+env:
+  DOTNET_NOLOGO: true
+
+jobs:
+  build-and-test:
+    name: build-and-test-${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'windows-latest', 'macOS-latest' ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET Core 3.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Setup .NET 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Install Ubuntu dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update &&
+        sudo apt-get install -y tesseract-ocr libleptonica-dev && 
+        ls -la /usr/local/lib && 
+        ls -la /usr/lib/x86_64-linux-gnu
+
+    - name: Install macOS dependencies
+      if: runner.os == 'macOS'
+      run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" &&
+        brew tap-new local/versions &&
+        brew extract --version=4.1.1 tesseract local/versions &&
+        brew install local/versions/tesseract@4.1.1 mono-libgdiplus
+    
+    - name: Install dependencies
+      run: dotnet restore src/Tesseract.sln
+      
+    - name: Build
+      run: dotnet build --configuration Release --no-restore src/Tesseract.sln
+    
+    - name: Test
+      run: dotnet test --configuration Release --no-build --verbosity normal --logger trx --results-directory "TestResults" src/Tesseract.sln
+    
+    - name: Upload dotnet test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: dotnet-results
+        path: TestResults
+      if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ 'ci-test' ]
+    branches: [ 'macos-fix' ]
   pull_request:
     branches: [ 'main', 'develop' ]
     paths:

--- a/docs/Get running on macOS.md
+++ b/docs/Get running on macOS.md
@@ -1,0 +1,16 @@
+To get .net wrapper for Tesseract working on macOS tesseract and leptonica libraries need to installed and linked in project.
+
+# Install libraries via Brew
+```sh
+brew install leptonica tesseract
+```
+
+# Add symlinks to output folder
+Add the following Target to the csproj.
+
+```xml
+<Target Name="link_deps" AfterTargets="AfterBuild">
+  <Exec Command="ln -sf /usr/local/lib/liblept.dylib $(OutDir)x64/libleptonica-1.80.0.dylib"/>
+  <Exec Command="ln -sf /usr/local/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
+</Target>
+```

--- a/src/Tesseract.Net48Tests/Tesseract.Net48Tests.csproj
+++ b/src/Tesseract.Net48Tests/Tesseract.Net48Tests.csproj
@@ -207,4 +207,13 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <Target Name="SymlinkLinuxDependencies" AfterTargets="AfterBuild" Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
+    <Exec Command="ln -sf /usr/lib/x86_64-linux-gnu/liblept.so $(OutDir)x64/libleptonica-1.80.0.so"/>
+    <Exec Command="ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.4 $(OutDir)x64/libtesseract41.so"/>
+  </Target>
+
+  <Target Name="SymlinkMacOSDependencies" AfterTargets="AfterBuild" Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
+    <Exec Command="ln -sf /usr/local/lib/liblept.dylib $(OutDir)x64/libleptonica-1.80.0.dylib"/>
+    <Exec Command="ln -sf /usr/local/Cellar/tesseract/4.1.3/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
+  </Target>
 </Project>

--- a/src/Tesseract.Net48Tests/Tesseract.Net48Tests.csproj
+++ b/src/Tesseract.Net48Tests/Tesseract.Net48Tests.csproj
@@ -214,6 +214,6 @@
 
   <Target Name="SymlinkMacOSDependencies" AfterTargets="AfterBuild" Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
     <Exec Command="ln -sf /usr/local/lib/liblept.dylib $(OutDir)x64/libleptonica-1.80.0.dylib"/>
-    <Exec Command="ln -sf /usr/local/Cellar/tesseract/4.1.3/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
+    <Exec Command="ln -sf /usr/local/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
   </Target>
 </Project>

--- a/src/Tesseract.NetCore31Tests/Tesseract.NetCore31Tests.csproj
+++ b/src/Tesseract.NetCore31Tests/Tesseract.NetCore31Tests.csproj
@@ -206,4 +206,13 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <Target Name="SymlinkLinuxDependencies" AfterTargets="AfterBuild" Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
+    <Exec Command="ln -sf /usr/lib/x86_64-linux-gnu/liblept.so $(OutDir)x64/libleptonica-1.80.0.so"/>
+    <Exec Command="ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.4 $(OutDir)x64/libtesseract41.so"/>
+  </Target>
+
+  <Target Name="SymlinkMacOSDependencies" AfterTargets="AfterBuild" Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
+    <Exec Command="ln -sf /usr/local/lib/liblept.dylib $(OutDir)x64/libleptonica-1.80.0.dylib"/>
+    <Exec Command="ln -sf /usr/local/Cellar/tesseract/4.1.3/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
+  </Target>
 </Project>

--- a/src/Tesseract.NetCore31Tests/Tesseract.NetCore31Tests.csproj
+++ b/src/Tesseract.NetCore31Tests/Tesseract.NetCore31Tests.csproj
@@ -213,6 +213,6 @@
 
   <Target Name="SymlinkMacOSDependencies" AfterTargets="AfterBuild" Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
     <Exec Command="ln -sf /usr/local/lib/liblept.dylib $(OutDir)x64/libleptonica-1.80.0.dylib"/>
-    <Exec Command="ln -sf /usr/local/Cellar/tesseract/4.1.3/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
+    <Exec Command="ln -sf /usr/local/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
   </Target>
 </Project>

--- a/src/Tesseract.Tests/AnalyseResultTests.cs
+++ b/src/Tesseract.Tests/AnalyseResultTests.cs
@@ -9,10 +9,10 @@ namespace Tesseract.Tests
     {
         private string ResultsDirectory
         {
-            get { return TestResultPath(@"Analysis\"); }
+            get { return TestResultPath(@"Analysis/"); }
         }
 
-        private const string ExampleImagePath = @"Ocr\phototest.tif";
+        private const string ExampleImagePath = @"Ocr/phototest.tif";
 
         #region Setup\TearDown
 
@@ -48,7 +48,7 @@ namespace Tesseract.Tests
             var exampleImagePath = TestFilePath("Ocr/phototest.tif");
             using (var img = LoadTestImage(ExampleImagePath)) {
                 using (var rotatedImage = angle.HasValue ? img.Rotate(MathHelper.ToRadians(angle.Value)) : img.Clone()) {
-                    rotatedImage.Save(TestResultRunFile(String.Format(@"AnalyseResult\AnalyseLayout_RotateImage_{0}.png", angle)));
+                    rotatedImage.Save(TestResultRunFile(String.Format(@"AnalyseResult/AnalyseLayout_RotateImage_{0}.png", angle)));
 
                     engine.DefaultPageSegMode = PageSegMode.AutoOsd;
                     using (var page = engine.Process(rotatedImage)) {
@@ -179,7 +179,7 @@ namespace Tesseract.Tests
                         // get symbol
                         int x, y;
                         using (var elementImg = pageLayout.GetImage(level, padding, out x, out y)) {
-                            var elementImgFilename = String.Format(@"AnalyseResult\GetImage\ResultIterator_Image_{0}_{1}_at_({2},{3}).png", level, padding, x, y);
+                            var elementImgFilename = String.Format(@"AnalyseResult/GetImage/ResultIterator_Image_{0}_{1}_at_({2},{3}).png", level, padding, x, y);
 
                             // TODO: Ensure generated pix is equal to expected pix, only saving it if it's not.
                             var destFilename = TestResultRunFile(elementImgFilename);

--- a/src/Tesseract.Tests/EngineTests.cs
+++ b/src/Tesseract.Tests/EngineTests.cs
@@ -110,7 +110,7 @@ namespace Tesseract.Tests
         public void CanParseUznFile()
         {
             using (var engine = CreateEngine()) {
-                var inputFilename = TestFilePath(@"Ocr\uzn-test.png");
+                var inputFilename = TestFilePath(@"Ocr/uzn-test.png");
                 using (var img = Pix.LoadFromFile(inputFilename)) {
                     using (var page = engine.Process(img, inputFilename, PageSegMode.SingleLine)) {
                         var text = page.GetText();
@@ -129,7 +129,7 @@ namespace Tesseract.Tests
         public void CanProcessBitmap()
         {
             using (var engine = CreateEngine()) {
-                var testImgFilename = TestFilePath(@"Ocr\phototest.tif");
+                var testImgFilename = TestFilePath(@"Ocr/phototest.tif");
                 using (var img = new Bitmap(testImgFilename)) {
                     using (var page = engine.Process(img)) {
                         var text = page.GetText();
@@ -217,7 +217,7 @@ namespace Tesseract.Tests
         {
             string actualResult;
             using (var engine = CreateEngine()) {
-                using (var img = LoadTestPix("ocr/empty.png")) {
+                using (var img = LoadTestPix("Ocr/empty.png")) {
                     using (var page = engine.Process(img)) {
                         actualResult = PageSerializer.Serialize(page, false);
                     }
@@ -253,7 +253,7 @@ TestUtils.NormaliseNewLine(@"</word></line>
         [Test]
         public void CanProcessPixUsingResultIterator()
         {
-            const string ResultPath = @"EngineTests\CanProcessPixUsingResultIterator.txt";
+            const string ResultPath = @"EngineTests/CanProcessPixUsingResultIterator.txt";
             var actualResultPath = TestResultRunFile(ResultPath);
 
             using (var engine = CreateEngine()) {
@@ -431,7 +431,7 @@ TestUtils.NormaliseNewLine(@"</word></line>
         [Test]
         public void CanProcessPixUsingResultIteratorAndChoiceIterator()
         {
-            const string resultFilename = @"EngineTests\CanProcessPixUsingResultIteratorAndChoiceIterator.txt";
+            const string resultFilename = @"EngineTests/CanProcessPixUsingResultIteratorAndChoiceIterator.txt";
 
             using (var engine = CreateEngine())
             {
@@ -628,14 +628,14 @@ TestUtils.NormaliseNewLine(@"</word></line>
             }
         }
 
-        #endregion Variable set\get
+        #endregion Variable set/get
 
         #region Variable print
 
         [Test]
         public void CanPrintVariables()
         {
-            const string ResultFilename = @"EngineTests\CanPrintVariables.txt";
+            const string ResultFilename = @"EngineTests/CanPrintVariables.txt";
             using (var engine = CreateEngine()) {
                 var actualResultsFilename = TestResultRunFile(ResultFilename);
                 Assert.That(engine.TryPrintVariablesToFile(actualResultsFilename), Is.True);

--- a/src/Tesseract.Tests/Leptonica/PixATests.cs
+++ b/src/Tesseract.Tests/Leptonica/PixATests.cs
@@ -22,7 +22,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void CanAddPixToPixArray()
         {
-            var sourcePixPath = TestFilePath(@"Ocr\phototest.tif");
+            var sourcePixPath = TestFilePath(@"Ocr/phototest.tif");
             using (var pixA = PixArray.Create(0))
             {
                 using (var sourcePix = Pix.LoadFromFile(sourcePixPath))
@@ -40,7 +40,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void CanRemovePixFromArray()
         {
-            var sourcePixPath = TestFilePath(@"Ocr\phototest.tif");
+            var sourcePixPath = TestFilePath(@"Ocr/phototest.tif");
             using (var pixA = PixArray.Create(0))
             {
                 using (var sourcePix = Pix.LoadFromFile(sourcePixPath))
@@ -56,7 +56,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void CanClearPixArray()
         {
-            var sourcePixPath = TestFilePath(@"Ocr\phototest.tif");
+            var sourcePixPath = TestFilePath(@"Ocr/phototest.tif");
             using (var pixA = PixArray.Create(0))
             {
                 using (var sourcePix = Pix.LoadFromFile(sourcePixPath))

--- a/src/Tesseract.Tests/Leptonica/PixTests/ImageManipulationTests.cs
+++ b/src/Tesseract.Tests/Leptonica/PixTests/ImageManipulationTests.cs
@@ -12,12 +12,12 @@ namespace Tesseract.Tests.Leptonica.PixTests
     [TestFixture]
     public class ImageManipulationTests : TesseractTestBase
     {
-        const string ResultsDirectory = @"Results\ImageManipulation\";
+        const string ResultsDirectory = @"Results/ImageManipulation/";
 
         [Test]
         public void DescewTest()
         {
-            var sourcePixPath = TestFilePath(@"Scew\scewed-phototest.png");
+            var sourcePixPath = TestFilePath(@"Scew/scewed-phototest.png");
             using (var sourcePix = Pix.LoadFromFile(sourcePixPath))
             {
                 Scew scew;
@@ -34,7 +34,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void OtsuBinarizationTest()
         {
-            var sourcePixFilename = TestFilePath(@"Binarization\neo-8bit.png");
+            var sourcePixFilename = TestFilePath(@"Binarization/neo-8bit.png");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             {
                 using (var binarizedImage = sourcePix.BinarizeOtsuAdaptiveThreshold(200, 200, 10, 10, 0.1F))
@@ -49,7 +49,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void SauvolaBinarizationTest()
         {
-            string sourcePixFilename = TestFilePath(@"Binarization\neo-8bit-grayscale.png");
+            string sourcePixFilename = TestFilePath(@"Binarization/neo-8bit-grayscale.png");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             {
                 using (var grayscalePix = sourcePix.ConvertRGBToGray(1, 1, 1))
@@ -67,7 +67,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void SauvolaTiledBinarizationTest()
         {
-            string sourcePixFilename = TestFilePath(@"Binarization\neo-8bit-grayscale.png");
+            string sourcePixFilename = TestFilePath(@"Binarization/neo-8bit-grayscale.png");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             {
                 using (var grayscalePix = sourcePix.ConvertRGBToGray(1, 1, 1))
@@ -85,7 +85,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void ConvertRGBToGrayTest()
         {
-            var sourcePixFilename = TestFilePath(@"Conversion\photo_rgb_32bpp.tif");
+            var sourcePixFilename = TestFilePath(@"Conversion/photo_rgb_32bpp.tif");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             using (var grayscaleImage = sourcePix.ConvertRGBToGray())
             {
@@ -105,7 +105,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
             const string FileNameFormat = "rotation_{0}degrees.jpg";
             float angleAsRadians = MathHelper.ToRadians(angle);
 
-            var sourcePixFilename = TestFilePath(@"Conversion\photo_rgb_32bpp.tif");
+            var sourcePixFilename = TestFilePath(@"Conversion/photo_rgb_32bpp.tif");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             {
                 using (var result = sourcePix.Rotate(angleAsRadians, RotationMethod.AreaMap))
@@ -120,7 +120,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void RemoveLinesTest()
         {
-            var sourcePixFilename = TestFilePath(@"processing\table.png");
+            var sourcePixFilename = TestFilePath(@"processing/table.png");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             {
                 // remove horizontal lines
@@ -147,7 +147,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         [Test]
         public void DespeckleTest()
         {
-            var sourcePixFilename = TestFilePath(@"processing\w91frag.jpg");
+            var sourcePixFilename = TestFilePath(@"processing/w91frag.jpg");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             {
                 // remove speckles
@@ -165,7 +165,7 @@ namespace Tesseract.Tests.Leptonica.PixTests
         {
             const string FileNameFormat = "scale_{0}.jpg";
 
-            var sourcePixFilename = TestFilePath(@"Conversion\photo_rgb_32bpp.tif");
+            var sourcePixFilename = TestFilePath(@"Conversion/photo_rgb_32bpp.tif");
             using (var sourcePix = Pix.LoadFromFile(sourcePixFilename))
             {
                 using (var result = sourcePix.Scale(scale, scale))

--- a/src/Tesseract.Tests/ResultIteratorTests/FontAttributesTests.cs
+++ b/src/Tesseract.Tests/ResultIteratorTests/FontAttributesTests.cs
@@ -17,7 +17,7 @@ namespace Tesseract.Tests.ResultIteratorTests
         public void Init()
         {
             Engine = CreateEngine();
-            TestImage = LoadTestPix("Ocr\\Fonts.tif");
+            TestImage = LoadTestPix("Ocr/Fonts.tif");
         }
 
         [TearDown]

--- a/src/Tesseract.Tests/ResultIteratorTests/OfAnEmptyPixTests.cs
+++ b/src/Tesseract.Tests/ResultIteratorTests/OfAnEmptyPixTests.cs
@@ -17,7 +17,7 @@ namespace Tesseract.Tests.ResultIteratorTests
         public void Init()
         {
             Engine = CreateEngine();
-            EmptyPix = LoadTestPix("Ocr\\blank.tif");
+            EmptyPix = LoadTestPix("Ocr/blank.tif");
         }
 
         [TearDown]

--- a/src/Tesseract.Tests/ResultRendererTests.cs
+++ b/src/Tesseract.Tests/ResultRendererTests.cs
@@ -35,7 +35,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoTextFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\Text\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/Text/phototest");
             using (var renderer = ResultRenderer.CreateTextRenderer(resultPath)) {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
                 ProcessFile(renderer, examplePixPath);
@@ -48,7 +48,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoPdfFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\PDF\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/PDF/phototest");
             using (var renderer = ResultRenderer.CreatePdfRenderer(resultPath, DataPath, false)) {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
                 ProcessFile(renderer, examplePixPath);
@@ -67,7 +67,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoPdfFile1()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\PDF\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/PDF/phototest");
             using (var renderer = ResultRenderer.CreatePdfRenderer(resultPath, DataPath, false))
             {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
@@ -81,7 +81,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderMultiplePageDocumentToPdfFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\PDF\multi-page");
+            var resultPath = TestResultRunFile(@"ResultRenderers/PDF/multi-page");
             using (var renderer = ResultRenderer.CreatePdfRenderer(resultPath, DataPath, false)) {
                 var examplePixPath = TestFilePath("processing/multi-page.tif");
                 ProcessMultipageTiff(renderer, examplePixPath);
@@ -100,7 +100,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderMultiplePageDocumentToPdfFile1()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\PDF\multi-page");
+            var resultPath = TestResultRunFile(@"ResultRenderers/PDF/multi-page");
             using (var renderer = ResultRenderer.CreatePdfRenderer(resultPath, DataPath, false))
             {
                 var examplePixPath = TestFilePath("processing/multi-page.tif");
@@ -114,7 +114,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoHOcrFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\HOCR\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/HOCR/phototest");
             using (var renderer = ResultRenderer.CreateHOcrRenderer(resultPath)) {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
                 ProcessFile(renderer, examplePixPath);
@@ -127,7 +127,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoUnlvFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\UNLV\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/UNLV/phototest");
             using (var renderer = ResultRenderer.CreateUnlvRenderer(resultPath)) {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
                 ProcessFile(renderer, examplePixPath);
@@ -140,7 +140,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoAltoFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\Alto\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/Alto/phototest");
             using (var renderer = ResultRenderer.CreateAltoRenderer(resultPath))
             {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
@@ -155,7 +155,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoTsvFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\Tsv\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/Tsv/phototest");
             using (var renderer = ResultRenderer.CreateTsvRenderer(resultPath))
             {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
@@ -169,7 +169,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoLSTMBoxFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\LSTMBox\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/LSTMBox/phototest");
             using (var renderer = ResultRenderer.CreateLSTMBoxRenderer(resultPath))
             {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
@@ -183,7 +183,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoWordStrBoxFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\WordStrBox\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/WordStrBox/phototest");
             using (var renderer = ResultRenderer.CreateWordStrBoxRenderer(resultPath))
             {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
@@ -197,7 +197,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoBoxFile()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\Box\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/Box/phototest");
             using (var renderer = ResultRenderer.CreateBoxRenderer(resultPath)) {
                 var examplePixPath = TestFilePath("Ocr/phototest.tif");
                 ProcessFile(renderer, examplePixPath);
@@ -210,7 +210,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderResultsIntoMultipleOutputFormats()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\PDF\phototest");
+            var resultPath = TestResultRunFile(@"ResultRenderers/PDF/phototest");
             List<RenderedFormat> formats = new List<RenderedFormat> { RenderedFormat.HOCR, RenderedFormat.PDF_TEXTONLY, RenderedFormat.TEXT };
             using (var renderer = new AggregateResultRenderer(ResultRenderer.CreateRenderers(resultPath, DataPath, formats)))
             {
@@ -229,7 +229,7 @@ namespace Tesseract.Tests
         [Test]
         public void CanRenderMultiplePageDocumentIntoMultipleResultRenderers()
         {
-            var resultPath = TestResultRunFile(@"ResultRenderers\Aggregate\multi-page");
+            var resultPath = TestResultRunFile(@"ResultRenderers/Aggregate/multi-page");
             using (var renderer = new AggregateResultRenderer(ResultRenderer.CreatePdfRenderer(resultPath, DataPath, false), ResultRenderer.CreateTextRenderer(resultPath))) {
                 var examplePixPath = TestFilePath("processing/multi-page.tif");
                 ProcessMultipageTiff(renderer, examplePixPath);

--- a/src/Tesseract/Internal/InteropDotNet/SystemManager.cs
+++ b/src/Tesseract/Internal/InteropDotNet/SystemManager.cs
@@ -2,6 +2,7 @@
 //  Project URL: https://github.com/AndreyAkinshin/InteropDotNet
 //  Distributed under the MIT License: http://opensource.org/licenses/MIT
 using System;
+using System.Runtime.InteropServices;
 
 namespace InteropDotNet
 {
@@ -14,6 +15,17 @@ namespace InteropDotNet
 
         public static OperatingSystem GetOperatingSystem()
         {
+            // Environment.OSVersion.Platform detects MacOS as Unix in .net core environment
+#if NETCORE || NETSTANDARD
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return OperatingSystem.Windows;
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return OperatingSystem.Unix;
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return OperatingSystem.MacOSX;
+            
+            return OperatingSystem.Unknown;
+#else
             var pid = (int)Environment.OSVersion.Platform;
             switch (pid)
             {
@@ -30,6 +42,7 @@ namespace InteropDotNet
                 default:
                     return OperatingSystem.Unknown;
             }
+#endif
         }
     }
 

--- a/src/Tesseract/Internal/InteropDotNet/UnixLibraryLoaderLogic.cs
+++ b/src/Tesseract/Internal/InteropDotNet/UnixLibraryLoaderLogic.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Andrey Akinshin
+﻿//  Copyright (c) 2014 Andrey Akinshin
 //  Project URL: https://github.com/AndreyAkinshin/InteropDotNet
 //  Distributed under the MIT License: http://opensource.org/licenses/MIT
 using System;
@@ -55,12 +55,14 @@ namespace InteropDotNet
             return functionHandle;
         }
 
+        private static readonly string FileExtension = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so";
+
         public string FixUpLibraryName(string fileName)
         {
             if (!string.IsNullOrEmpty(fileName))
             {
-                if (!fileName.EndsWith(".so", StringComparison.OrdinalIgnoreCase))
-                    fileName += ".so";
+                if (!fileName.EndsWith(FileExtension, StringComparison.OrdinalIgnoreCase))
+                    fileName += FileExtension;
                 if (!fileName.StartsWith("lib", StringComparison.OrdinalIgnoreCase))
                     fileName = "lib" + fileName;
             }

--- a/src/Tesseract/Internal/InteropDotNet/UnixLibraryLoaderLogic.cs
+++ b/src/Tesseract/Internal/InteropDotNet/UnixLibraryLoaderLogic.cs
@@ -55,7 +55,7 @@ namespace InteropDotNet
             return functionHandle;
         }
 
-        private static readonly string FileExtension = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so";
+        private static readonly string FileExtension = SystemManager.GetOperatingSystem() == OperatingSystem.MacOSX ? ".dylib" : ".so";
 
         public string FixUpLibraryName(string fileName)
         {

--- a/src/Tesseract/Internal/InteropDotNet/UnixLibraryLoaderLogic.cs
+++ b/src/Tesseract/Internal/InteropDotNet/UnixLibraryLoaderLogic.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2014 Andrey Akinshin
+//  Copyright (c) 2014 Andrey Akinshin
 //  Project URL: https://github.com/AndreyAkinshin/InteropDotNet
 //  Distributed under the MIT License: http://opensource.org/licenses/MIT
 using System;
@@ -69,16 +69,16 @@ namespace InteropDotNet
 
         const int RTLD_NOW = 2;
 
-        [DllImport("libdl.so", EntryPoint = "dlopen")]
+        [DllImport("libdl", EntryPoint = "dlopen")]
         private static extern IntPtr UnixLoadLibrary(String fileName, int flags);
 
-        [DllImport("libdl.so", EntryPoint = "dlclose", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        [DllImport("libdl", EntryPoint = "dlclose", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         private static extern int UnixFreeLibrary(IntPtr handle);
 
-        [DllImport("libdl.so", EntryPoint = "dlsym", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        [DllImport("libdl", EntryPoint = "dlsym", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         private static extern IntPtr UnixGetProcAddress(IntPtr handle, String symbol);
 
-        [DllImport("libdl.so", EntryPoint = "dlerror", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        [DllImport("libdl", EntryPoint = "dlerror", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         private static extern IntPtr UnixGetLastError();
     }
 }


### PR DESCRIPTION
P/Invoke calls use linux specific filename of `libdl.so`. By removing the file extension P/Invoke selects automatically the right one on Linux (`.so`) and MacOS (`.dylib`).