### PR TITLE
Update Get running on macOS.md for Apple Silicon

### DIFF
--- a/docs/Get running on macOS.md
+++ b/docs/Get running on macOS.md
@@ -8,9 +8,18 @@ brew install leptonica tesseract
 # Add symlinks to output folder
 Add the following Target to the csproj.
 
+Apple silicon Mac
 ```xml
 <Target Name="link_deps" AfterTargets="AfterBuild">
-  <Exec Command="ln -sf /usr/local/lib/liblept.dylib $(OutDir)x64/libleptonica-1.80.0.dylib"/>
-  <Exec Command="ln -sf /usr/local/lib/libtesseract.dylib $(OutDir)x64/libtesseract41.dylib"/>
+  <Exec Command="ln -sf /opt/homebrew/lib/libleptonica.dylib $(OutDir)x64/libleptonica-1.82.0.dylib" />
+  <Exec Command="ln -sf /opt/homebrew/lib/libtesseract.dylib $(OutDir)x64/libtesseract50.dylib" />
+</Target>
+```
+
+Intel Mac
+```xml
+<Target Name="link_deps" AfterTargets="AfterBuild">
+  <Exec Command="ln -sf /usr/local/lib/liblept.dylib $(OutDir)x64/libleptonica-1.82.0.dylib"/>
+  <Exec Command="ln -sf /usr/local/lib/libtesseract.dylib $(OutDir)x64/libtesseract50.dylib"/>
 </Target>
 ```


### PR DESCRIPTION
Updated the macOS instructions to point to the currently used version of Leptonica and Tesseract. Also added in instruction for Apple Silicon Macs based on the homebrew [documentation](https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location). Tested it on a Mac with an M1 Pro. 